### PR TITLE
Add ImageTranforms to include options

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Currently, Rest Api supports the following HTTP verbs:
 
 Example endpoints include:
 
+* `GET  http://example.com/api/Asset?id=44&include=transforms` returns an image asset with the id of 44 with all available image transformation urls and sizes
 * `GET  http://example.com/api/Entry?page=2&limit=10&order=postDate asc`__ returns the second page of a paginated listing of 10 Entry elements, ordered by the `postDate` attribute in ascending order
 * `GET http://example.com/api/Entry/2` returns the entry with the element id of 2
 * `POST http://example.com/api/Entry` creates a new Entry element

--- a/src/Transformers/AssetFileTransformer.php
+++ b/src/Transformers/AssetFileTransformer.php
@@ -7,6 +7,17 @@ use Craft\AssetFileModel;
 class AssetFileTransformer extends BaseTransformer
 {
     /**
+     * Constructor
+     */
+    public function __construct()
+    {
+        $this->availableIncludes = array_merge($this->availableIncludes, [
+            'transforms',
+        ]);
+    }
+
+
+    /**
      * Transform
      *
      * @param AssetFileModel $element Asset
@@ -22,22 +33,43 @@ class AssetFileTransformer extends BaseTransformer
             'locale'        => $element->locale,
             'localeEnabled' => (bool) $element->localeEnabled,
             'slug'          => $element->slug,
-            'uri'           => $element->uri,
+            'url'           => $element->getUrl(),
             'dateCreated'   => $element->dateCreated,
             'dateUpdated'   => $element->dateUpdated,
             'root'          => ($element->root) ? (int) $element->root : null,
             'lft'           => ($element->lft) ? (int) $element->lft : null,
             'rgt'           => ($element->rgt) ? (int) $element->rgt : null,
             'level'         => ($element->level) ? (int) $element->level : null,
-            'sourceId'      => (int) $element->folderId,
-            'folderId'      => (int) $element->filename,
+            'sourceId'      => (int) $element->sourceId,
+            'folderId'      => (int) $element->folderId,
             'originalName'  => $element->originalName,
+            'fileName'      => $element->filename,
+            'extension'     => $element->extension,
+            'mimeType'      => $element->mimeType,
             'kind'          => $element->kind,
             'width'         => (int) $element->width,
             'height'        => (int) $element->height,
             'size'          => (int) $element->size,
-            'dateModified'  => $element->dateModified,
+            'dateModified'  => $element->dateModified
         ];
     }
+
+
+    /**
+     * Include Type
+     *
+     * @param AssetFileModel $element Asset
+     *
+     * @return array Asset
+     */
+    public function includeTransforms(AssetFileModel $element)
+    {
+        $imgTag = $element->getImg();
+
+        if ($imgTag) {
+            return $this->item($element, new ImgTransformsTransformer);
+        }
+    }
+
 
 }

--- a/src/Transformers/ImgTransformsTransformer.php
+++ b/src/Transformers/ImgTransformsTransformer.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace RestfulApi\Transformers;
+
+use Craft\AssetFileModel;
+
+class ImgTransformsTransformer extends BaseTransformer
+{
+    /**
+     * Transform
+     *
+     * @param AssetFileModel $element Asset
+     *
+     * @return array Asset
+     */
+    public function transform(AssetFileModel $element)
+    {
+        $transforms = \Craft\craft()->assetTransforms->allTransforms;
+        $toReturn = [];
+
+        foreach($transforms as $transform){
+            $handle = $transform->handle;
+            $toReturn[$handle]['url'] = $element->getUrl($handle);
+            $toReturn[$handle]['width'] = $element->getWidth($handle);
+            $toReturn[$handle]['height'] = $element->getHeight($handle);
+        }
+
+        return $toReturn;
+    }
+}


### PR DESCRIPTION
This is a rather basic way using transforms to add a list of available image transformations. A cleaner version would allow you to specify the handle you are after, however for now this does the trick.

Works only with assets that declare their 'kind' as image. Only provides URL, width and height (no information from the transformation itself, such as whether it's cropped/stretched etc)
